### PR TITLE
Fix an error on parsing

### DIFF
--- a/lib/licensir/scanner.ex
+++ b/lib/licensir/scanner.ex
@@ -10,10 +10,10 @@ defmodule Licensir.Scanner do
     cc0: "CC0-1.0",
     gpl_v2: "GPLv2",
     gpl_v3: "GPLv3",
-    isc: ["ISC"],
-    lgpl: ["LGPL"],
-    mit: ["MIT"],
-    mpl2: ["MPL2"],
+    isc: "ISC",
+    lgpl: "LGPL",
+    mit: "MIT",
+    mpl2: "MPL2",
   }
 
   @doc """


### PR DESCRIPTION
warning: String.strip/1 is deprecated, use String.trim/1
  .../deps/poison/mix.exs:4

** (ArgumentError) argument error
    :erlang.byte_size(["MIT"])
    lib/licensir/scanner.ex:86: Licensir.Scanner.guess_license/2
    lib/licensir/scanner.ex:77: Licensir.Scanner.guess_license/1
    (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
    (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
    lib/mix/tasks/licenses.ex:16: Mix.Tasks.Licenses.run/1
    (mix) lib/mix/task.ex:314: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:80: Mix.CLI.run_task/2
mix licenses  2.78s user 1.30s system 137% cpu 2.973 total