### PR TITLE
Fixes two warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ language: elixir
 elixir:
   - '1.5.3'
   - '1.6.4'
+  - '1.8.1'
 
 otp_release:
   - '19.3'
   - '20.3'
+  - '21.3'
 
 env:
   - MIX_ENV=test

--- a/lib/licensir/scanner.ex
+++ b/lib/licensir/scanner.ex
@@ -34,7 +34,18 @@ defmodule Licensir.Scanner do
   end
 
   @spec deps() :: list(Mix.Dep.t())
-  defp deps(), do: Mix.Dep.load_on_environment([])
+  defp deps() do
+    func = loaded_deps_func_name()
+    apply(Mix.Dep, func, [[]])
+  end
+
+  defp loaded_deps_func_name() do
+    if Keyword.has_key?(Mix.Dep.__info__(:functions), :load_on_environment) do
+      :load_on_environment
+    else
+      :loaded
+    end
+  end
 
   defp to_struct(deps) when is_list(deps), do: Enum.map(deps, &to_struct/1)
 

--- a/lib/licensir/scanner.ex
+++ b/lib/licensir/scanner.ex
@@ -34,7 +34,7 @@ defmodule Licensir.Scanner do
   end
 
   @spec deps() :: list(Mix.Dep.t())
-  defp deps(), do: Mix.Dep.loaded([])
+  defp deps(), do: Mix.Dep.load_on_environment([])
 
   defp to_struct(deps) when is_list(deps), do: Enum.map(deps, &to_struct/1)
 

--- a/test/fixtures/deps/dep_one_unrecognized_license_file/mix.exs
+++ b/test/fixtures/deps/dep_one_unrecognized_license_file/mix.exs
@@ -1,4 +1,4 @@
-defmodule DepOneLicense.MixProject do
+defmodule DepOneUnrecognizedLicense.MixProject do
   use Mix.Project
 
   def project do


### PR DESCRIPTION
```
warning: redefining module DepOneLicense.MixProject (current version defined in memory)
  test/fixtures/deps/dep_one_unrecognized_license_file/mix.exs:1

warning: Mix.Dep.loaded/1 is deprecated. Mix.Dep.loaded/1 was private API and you should not use it
  lib/licensir/scanner.ex:35
```