### PR TITLE
Support --top-level-only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ ranch 1.4.0             -> Undefined
 websocket_client        -> Undefined
 ```
 
+## Flags
+* `--top-level-only` - Only fetch license information from top level dependencies (e.g. packages that are directly listed in `mix.exs`) Excludes transitive dependencies.
+
 ## License
 
 Copyright (c) 2017-2019, Unnawut Leepaisalsuwanna.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ websocket_client        -> Undefined
 ```
 
 ## Flags
-* `--top-level-only` - Only fetch license information from top level dependencies (e.g. packages that are directly listed in `mix.exs`) Excludes transitive dependencies.
+* `--top-level-only` - Only fetch license information from top level dependencies (e.g. packages that are directly listed in your application's `mix.exs`). Excludes transitive dependencies.
 
 ## License
 

--- a/lib/licensir/scanner.ex
+++ b/lib/licensir/scanner.ex
@@ -60,7 +60,7 @@ defmodule Licensir.Scanner do
   end
 
   defp filter_top_level(deps, opts) do
-    if Keyword.get(opts, :top_level_only, false) do
+    if Keyword.get(opts, :top_level_only) do
       Enum.filter(deps, &(&1.dep.top_level))
     else
       deps

--- a/lib/licensir/scanner.ex
+++ b/lib/licensir/scanner.ex
@@ -21,13 +21,14 @@ defmodule Licensir.Scanner do
   @doc """
   Scans all dependencies, formats into a list, and print out the result.
   """
-  @spec scan() :: list(License.t())
-  def scan() do
+  @spec scan(keyword()) :: list(License.t())
+  def scan(opts) do
     # Make sure the dependencies are loaded
     Mix.Project.get!()
 
     deps()
     |> to_struct()
+    |> filter_top_level(opts)
     |> search_hex_metadata()
     |> search_file()
     |> Guesser.guess()
@@ -56,6 +57,14 @@ defmodule Licensir.Scanner do
       version: get_version(dep),
       dep: dep
     }
+  end
+
+  defp filter_top_level(deps, opts) do
+    if Keyword.get(opts, :top_level_only, false) do
+      Enum.filter(deps, &(&1.dep.top_level))
+    else
+      deps
+    end
   end
 
   defp get_version(%Mix.Dep{status: {:ok, version}}), do: version

--- a/lib/mix/tasks/licenses.ex
+++ b/lib/mix/tasks/licenses.ex
@@ -15,9 +15,9 @@ defmodule Mix.Tasks.Licenses do
   def run(argv) do
     Mix.Shell.IO.info([:yellow, "Notice: This is not a legal advice. Use the information below at your own risk."])
 
-    opts = [
-      top_level_only: Enum.member?(argv, "--top-level-only")
-    ]
+    {opts, _argv} = OptionParser.parse!(argv, switches: [
+      top_level_only: :boolean
+    ])
 
     Licensir.Scanner.scan(opts)
     |> Enum.sort_by(fn license -> license.name end)

--- a/lib/mix/tasks/licenses.ex
+++ b/lib/mix/tasks/licenses.ex
@@ -12,10 +12,14 @@ defmodule Mix.Tasks.Licenses do
 
   @name_width 24
 
-  def run(_argv) do
+  def run(argv) do
     Mix.Shell.IO.info([:yellow, "Notice: This is not a legal advice. Use the information below at your own risk."])
 
-    Licensir.Scanner.scan()
+    opts = [
+      top_level_only: Enum.member?(argv, "--top-level-only")
+    ]
+
+    Licensir.Scanner.scan(opts)
     |> Enum.sort_by(fn license -> license.name end)
     |> Enum.map(&print_license/1)
     |> Mix.Shell.IO.info()

--- a/test/fixtures/deps/dep_of_dep/mix.exs
+++ b/test/fixtures/deps/dep_of_dep/mix.exs
@@ -1,0 +1,16 @@
+defmodule DepOfDep.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dep_of_dep,
+      version: "0.0.1",
+      package: package()
+    ]
+  end
+
+  defp package do
+    [
+    ]
+  end
+end

--- a/test/fixtures/deps/dep_with_dep/mix.exs
+++ b/test/fixtures/deps/dep_with_dep/mix.exs
@@ -1,0 +1,23 @@
+defmodule DepWithDep.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dep_with_dep,
+      version: "0.0.1",
+      package: package(),
+      deps: deps()
+    ]
+  end
+
+  defp package do
+    [
+    ]
+  end
+
+  defp deps do
+    [
+      {:dep_of_dep, path: "../dep_of_dep"}
+    ]
+  end
+end

--- a/test/licensir/scanner_test.exs
+++ b/test/licensir/scanner_test.exs
@@ -2,7 +2,7 @@ defmodule Licensir.ScannerTest do
   use Licensir.Case
 
   test "returns a list of Licensir.Licenses struct" do
-    licenses = Licensir.Scanner.scan()
+    licenses = Licensir.Scanner.scan([])
 
     assert Enum.all?(licenses, fn license ->
              license.__struct__ == Licensir.License
@@ -10,11 +10,18 @@ defmodule Licensir.ScannerTest do
   end
 
   test "returns a list of Licensir.TestApp's licenses" do
-    licenses = Licensir.Scanner.scan()
+    licenses = Licensir.Scanner.scan([])
 
     assert has_license?(licenses, %{app: :dep_one_license})
     assert has_license?(licenses, %{app: :dep_two_licenses})
     assert has_license?(licenses, %{app: :dep_license_undefined})
+  end
+
+  test "can filter Licensir.TestApp's dependencies for top-level only" do
+    licenses = Licensir.Scanner.scan([top_level_only: true])
+
+    assert has_license?(licenses, %{app: :dep_with_dep})
+    refute has_license?(licenses, %{app: :dep_of_dep})
   end
 
   defp has_license?(licenses, search_map) do

--- a/test/mix/tasks/licenses_test.exs
+++ b/test/mix/tasks/licenses_test.exs
@@ -12,11 +12,13 @@ defmodule Licensir.Mix.Tasks.LicensesTest do
       IO.ANSI.format([
         [:yellow, "Notice: This is not a legal advice. Use the information below at your own risk."], :reset, "\n",
         "dep_license_undefined   -> ", [:red, "Undefined"], :reset, "\n",
+        "dep_of_dep              -> ", [:red, "Undefined"], :reset, "\n",
         "dep_one_license         -> ", [:green, "Licensir Mock License"], :reset, "\n",
         "dep_one_unrecognized_license_file -> ", [:red, "Unrecognized license file content"], :reset, "\n",
         "dep_two_conflicting_licenses -> ", [:yellow, "Unsure (found: License One, Licensir Mock License)"], :reset, "\n",
         "dep_two_licenses        -> ", [:green, "License Two, License Three"], :reset, "\n",
-        "dep_two_variants_same_license -> ", [:green, "Apache 2.0"], :reset, "\n"
+        "dep_two_variants_same_license -> ", [:green, "Apache 2.0"], :reset, "\n",
+        "dep_with_dep            -> ", [:red, "Undefined"], :reset, "\n"
       ])
       |> to_string()
       |> Kernel.<>("\n")

--- a/test/support/test_app.ex
+++ b/test/support/test_app.ex
@@ -2,6 +2,7 @@ defmodule Licensir.TestApp do
   def project do
     [
       deps: [
+        {:dep_with_dep, path: "test/fixtures/deps/dep_with_dep"},
         {:dep_one_license, path: "test/fixtures/deps/dep_one_license"},
         {:dep_two_licenses, path: "test/fixtures/deps/dep_two_licenses"},
         {:dep_license_undefined, path: "test/fixtures/deps/dep_license_undefined"},


### PR DESCRIPTION
This PR adds the possibility to use the `--top-level-only` option for only fetching information about top-level dependencies.