### PR TITLE
Add LICENSE.txt as valid source for license information

### DIFF
--- a/lib/licensir/file_analyzer.ex
+++ b/lib/licensir/file_analyzer.ex
@@ -1,6 +1,6 @@
 defmodule Licensir.FileAnalyzer do
   # The file names to check for licenses
-  @license_files ["LICENSE", "LICENSE.md"]
+  @license_files ["LICENSE", "LICENSE.md", "LICENSE.txt"]
 
   # The files that contain the actual text for each license
   @files [


### PR DESCRIPTION
Sorry to flood you with PR's, I'm currently working on extracting library information from quite a large project 😄 

This PR adds `LICENSE.txt` as a valid source for license information. I have found quite a few elixir dependencies that use a `.txt` file and some open source "guide" sites that recommend it along side `LICENSE` and `LICENSE.md`, so I think it makes sense to be scanned as well.