### PR TITLE
Add Apache-2.0 variant

### DIFF
--- a/lib/licensir/naming_variants.ex
+++ b/lib/licensir/naming_variants.ex
@@ -6,7 +6,8 @@ defmodule Licensir.NamingVariants do
     # Apache 2.0
     "Apache 2" => "Apache 2.0",
     "Apache v2.0" => "Apache 2.0",
-    "Apache 2 (see the file LICENSE for details)" => "Apache 2.0"
+    "Apache 2 (see the file LICENSE for details)" => "Apache 2.0",
+    "Apache-2.0" => "Apache 2.0"
   }
 
   @doc """

--- a/test/licensir/naming_variants_test.exs
+++ b/test/licensir/naming_variants_test.exs
@@ -7,6 +7,7 @@ defmodule Licensir.NamingVariantsTest do
       assert NamingVariants.normalize("Apache 2.0") == "Apache 2.0"
       assert NamingVariants.normalize("Apache 2") == "Apache 2.0"
       assert NamingVariants.normalize("Apache v2.0") == "Apache 2.0"
+      assert NamingVariants.normalize("Apache-2.0") == "Apache 2.0"
     end
 
     test "normalizes nil to nil" do


### PR DESCRIPTION
This adds another variant of the Apache 2.0 license. The `Apache-2.0` spelling comes from https://spdx.org/licenses/. 