### PR TITLE
Add support for `.licensir.exs` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,4 @@ This project contains 3rd party work as follow:
 
 - ASCII table rendering: a [partial copy](./lib/table_rex) of [djm/table_rex](https://github.com/djm/table_rex).
 - CSV rendering: a [partial copy](./lib/csv) of [beatrichartz/csv](https://github.com/beatrichartz/csv).
+- Config parsing: a [partial copy](./lib/credo) of [rrrene/credo](https://github.com/rrrene/credo)

--- a/lib/credo/LICENSE
+++ b/lib/credo/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2015-2020 René Föhring
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/credo/README.md
+++ b/lib/credo/README.md
@@ -1,0 +1,4 @@
+This directory contains a copy of [rrrene/credo](https://github.com/rrrene/credo).
+
+A hard copy is used instead of a dependency so that `mix archive.install ...`,
+which does not recognize the archive's defined dependencies, is supported.

--- a/lib/credo/exs_loader.ex
+++ b/lib/credo/exs_loader.ex
@@ -1,0 +1,76 @@
+defmodule Credo.ExsLoader do
+  @moduledoc false
+
+  def parse(exs_string) do
+    case Code.string_to_quoted(exs_string) do
+      {:ok, ast} ->
+        {:ok, process_exs(ast)}
+
+      {:error, {line_meta, message, trigger}} when is_list(line_meta) ->
+        {:error, {line_meta[:line], message, trigger}}
+
+      {:error, value} ->
+        {:error, value}
+    end
+  end
+
+  defp process_exs(v)
+       when is_atom(v) or is_binary(v) or is_float(v) or is_integer(v),
+       do: v
+
+  defp process_exs(list) when is_list(list) do
+    Enum.map(list, &process_exs/1)
+  end
+
+  defp process_exs({:sigil_w, _, [{:<<>>, _, [list_as_string]}, []]}) do
+    String.split(list_as_string, ~r/\s+/)
+  end
+
+  # TODO: support regex modifiers
+  defp process_exs({:sigil_r, _, [{:<<>>, _, [regex_as_string]}, []]}) do
+    Regex.compile!(regex_as_string)
+  end
+
+  defp process_exs({:%{}, _meta, body}) do
+    process_map(body, %{})
+  end
+
+  defp process_exs({:{}, _meta, body}) do
+    process_tuple(body, {})
+  end
+
+  defp process_exs({:__aliases__, _meta, name_list}) do
+    Module.safe_concat(name_list)
+  end
+
+  defp process_exs({{:__aliases__, _meta, name_list}, options}) do
+    {Module.safe_concat(name_list), process_exs(options)}
+  end
+
+  defp process_exs({key, value}) when is_atom(key) or is_binary(key) do
+    {process_exs(key), process_exs(value)}
+  end
+
+  defp process_tuple([], acc), do: acc
+
+  defp process_tuple([head | tail], acc) do
+    acc = process_tuple_item(head, acc)
+    process_tuple(tail, acc)
+  end
+
+  defp process_tuple_item(value, acc) do
+    Tuple.append(acc, process_exs(value))
+  end
+
+  defp process_map([], acc), do: acc
+
+  defp process_map([head | tail], acc) do
+    acc = process_map_item(head, acc)
+    process_map(tail, acc)
+  end
+
+  defp process_map_item({key, value}, acc)
+       when is_atom(key) or is_binary(key) do
+    Map.put(acc, key, process_exs(value))
+  end
+end

--- a/lib/licensir/config_file.ex
+++ b/lib/licensir/config_file.ex
@@ -1,0 +1,28 @@
+defmodule Licensir.ConfigFile do
+  @moduledoc """
+  Parse a project's .licensir.exs file to determine what licenses are acceptable to the user, not acceptable, and projects that are allowed
+  """
+
+  @config_filename ".licensir.exs"
+
+  defstruct allowlist: [], denylist: [], allow_deps: []
+
+  def parse(nil), do: parse(@config_filename)
+  def parse(file) do
+    if File.exists?(file) do
+      {:ok, raw} =
+        file
+        |> File.read!()
+        |> Credo.ExsLoader.parse()
+
+      {:ok,
+       %__MODULE__{
+         allowlist: raw[:allowlist] || [],
+         denylist: raw[:denylist] || [],
+         allow_deps: Enum.map(raw[:allow_deps] || [], &Atom.to_string/1)
+       }}
+    else
+      {:ok, %__MODULE__{}}
+    end
+  end
+end

--- a/lib/licensir/license.ex
+++ b/lib/licensir/license.ex
@@ -21,6 +21,7 @@ defmodule Licensir.License do
             license: nil,
             certainty: 0.0,
             mix: nil,
+            status: :unknown,
             hex_metadata: nil,
             file: nil
 
@@ -33,6 +34,9 @@ defmodule Licensir.License do
           certainty: float(),
           mix: list(String.t()) | nil,
           hex_metadata: list(String.t()) | nil,
+          status: status(),
           file: String.t() | nil
         }
+
+  @type status :: :allowed | :not_allowed | :unknown
 end

--- a/lib/mix/tasks/licenses.ex
+++ b/lib/mix/tasks/licenses.ex
@@ -19,15 +19,31 @@ defmodule Mix.Tasks.Licenses do
   def run(argv) do
     {opts, _argv} = OptionParser.parse!(argv, switches: @switches)
 
-    Licensir.Scanner.scan(opts)
-    |> Enum.sort_by(fn license -> license.name end)
+    licenses =
+      opts
+      |> Licensir.Scanner.scan()
+      |> Enum.sort_by(fn license -> license.name end)
+
+    licenses
     |> Enum.map(&to_row/1)
     |> render(opts)
+
+    exit_status(licenses)
+  end
+
+  defp exit_status(licenses) do
+    if Enum.any?(licenses, &(&1.status == :not_allowed)) do
+      exit({:shutdown, 1})
+    end
   end
 
   defp to_row(map) do
-    [map.name, map.version, map.license]
+    [map.name, map.version, map.license, license_status(map.status)]
   end
+
+  def license_status(:allowed), do: "Allowed"
+  def license_status(:not_allowed), do: "Not allowed"
+  def license_status(_), do: "Unknown"
 
   defp render(rows, opts) do
     cond do
@@ -40,13 +56,13 @@ defmodule Mix.Tasks.Licenses do
     _ = Mix.Shell.IO.info([:yellow, "Notice: This is not a legal advice. Use the information below at your own risk."])
 
     rows
-    |> TableRex.quick_render!(["Package", "Version", "License"])
+    |> TableRex.quick_render!(["Package", "Version", "License", "Status"])
     |> IO.puts()
   end
 
   defp render_csv(rows) do
     rows
-    |> List.insert_at(0, ["Package", "Version", "License"])
+    |> List.insert_at(0, ["Package", "Version", "License", "Status"])
     |> CSV.encode()
     |> Enum.each(&IO.write/1)
   end

--- a/test/fixtures/licensir-config.exs
+++ b/test/fixtures/licensir-config.exs
@@ -1,0 +1,5 @@
+%{
+  allowlist: ["MIT", "Apache 2.0"],
+  denylist: ["GPLv2", "Licensir Mock License"],
+  allow_deps: [:dep_mock_license]
+}

--- a/test/licensir/config_file_test.exs
+++ b/test/licensir/config_file_test.exs
@@ -1,0 +1,13 @@
+defmodule Licensir.ConfigFileTest do
+  use Licensir.Case
+  alias Licensir.{ConfigFile}
+
+  describe "parse" do
+    test "returns options" do
+      assert {:ok, config} = ConfigFile.parse("test/fixtures/licensir-config.exs")
+      assert config.allowlist == ["MIT", "Apache 2.0"]
+      assert config.denylist == ["GPLv2", "Licensir Mock License"]
+      assert config.allow_deps == ["dep_mock_license"]
+    end
+  end
+end

--- a/test/licensir/scanner_test.exs
+++ b/test/licensir/scanner_test.exs
@@ -24,6 +24,22 @@ defmodule Licensir.ScannerTest do
     refute has_license?(licenses, %{app: :dep_of_dep})
   end
 
+  test "returns the acceptability of the license" do
+    licenses = Licensir.Scanner.scan([config_file: "test/fixtures/licensir-config.exs"])
+
+    not_allowed_license = Enum.find(licenses, & &1.name == "dep_one_license")
+    assert not_allowed_license.status == :not_allowed
+
+    unknown_license = Enum.find(licenses, & &1.name == "dep_license_undefined")
+    assert unknown_license.status == :unknown
+
+    allowed_license = Enum.find(licenses, & &1.name == "dep_two_variants_same_license")
+    assert allowed_license.status == :allowed
+
+    allowed_app = Enum.find(licenses, & &1.name == "dep_mock_license")
+    assert allowed_app.status == :allowed
+  end
+
   defp has_license?(licenses, search_map) do
     Enum.any?(licenses, fn license ->
       Map.merge(license, search_map) == license

--- a/test/mix/tasks/licenses_test.exs
+++ b/test/mix/tasks/licenses_test.exs
@@ -11,18 +11,19 @@ defmodule Licensir.Mix.Tasks.LicensesTest do
     expected =
       IO.ANSI.format_fragment([
         [:yellow, "Notice: This is not a legal advice. Use the information below at your own risk."], :reset, "\n",
-        "+-----------------------------------+---------+----------------------------------------------------+", "\n",
-        "| Package                           | Version | License                                            |", "\n",
-        "+-----------------------------------+---------+----------------------------------------------------+", "\n",
-        "| dep_license_undefined             |         | Undefined                                          |", "\n",
-        "| dep_of_dep                        |         | Undefined                                          |", "\n",
-        "| dep_one_license                   |         | Licensir Mock License                              |", "\n",
-        "| dep_one_unrecognized_license_file |         | Unrecognized license file content                  |", "\n",
-        "| dep_two_conflicting_licenses      |         | Unsure (found: License One, Licensir Mock License) |", "\n",
-        "| dep_two_licenses                  |         | License Two, License Three                         |", "\n",
-        "| dep_two_variants_same_license     |         | Apache 2.0                                         |", "\n",
-        "| dep_with_dep                      |         | Undefined                                          |", "\n",
-        "+-----------------------------------+---------+----------------------------------------------------+", "\n", "\n"
+        "+-----------------------------------+---------+----------------------------------------------------+---------+", "\n",
+        "| Package                           | Version | License                                            | Status  |", "\n",
+        "+-----------------------------------+---------+----------------------------------------------------+---------+", "\n",
+        "| dep_license_undefined             |         | Undefined                                          | Unknown |", "\n",
+        "| dep_mock_license                  |         | Licensir Mock License                              | Unknown |", "\n",
+        "| dep_of_dep                        |         | Undefined                                          | Unknown |", "\n",
+        "| dep_one_license                   |         | Licensir Mock License                              | Unknown |", "\n",
+        "| dep_one_unrecognized_license_file |         | Unrecognized license file content                  | Unknown |", "\n",
+        "| dep_two_conflicting_licenses      |         | Unsure (found: License One, Licensir Mock License) | Unknown |", "\n",
+        "| dep_two_licenses                  |         | License Two, License Three                         | Unknown |", "\n",
+        "| dep_two_variants_same_license     |         | Apache 2.0                                         | Unknown |", "\n",
+        "| dep_with_dep                      |         | Undefined                                          | Unknown |", "\n",
+        "+-----------------------------------+---------+----------------------------------------------------+---------+", "\n", "\n"
       ])
       |> to_string()
 
@@ -37,15 +38,16 @@ defmodule Licensir.Mix.Tasks.LicensesTest do
 
     expected =
       """
-      Package,Version,License\r
-      dep_license_undefined,,Undefined\r
-      dep_of_dep,,Undefined\r
-      dep_one_license,,Licensir Mock License\r
-      dep_one_unrecognized_license_file,,Unrecognized license file content\r
-      dep_two_conflicting_licenses,,"Unsure (found: License One, Licensir Mock License)"\r
-      dep_two_licenses,,"License Two, License Three"\r
-      dep_two_variants_same_license,,Apache 2.0\r
-      dep_with_dep,,Undefined\r
+      Package,Version,License,Status\r
+      dep_license_undefined,,Undefined,Unknown\r
+      dep_mock_license,,Licensir Mock License,Unknown\r
+      dep_of_dep,,Undefined,Unknown\r
+      dep_one_license,,Licensir Mock License,Unknown\r
+      dep_one_unrecognized_license_file,,Unrecognized license file content,Unknown\r
+      dep_two_conflicting_licenses,,"Unsure (found: License One, Licensir Mock License)",Unknown\r
+      dep_two_licenses,,"License Two, License Three",Unknown\r
+      dep_two_variants_same_license,,Apache 2.0,Unknown\r
+      dep_with_dep,,Undefined,Unknown\r
       """
 
     assert output == expected

--- a/test/support/test_app.ex
+++ b/test/support/test_app.ex
@@ -8,7 +8,8 @@ defmodule Licensir.TestApp do
         {:dep_license_undefined, path: "test/fixtures/deps/dep_license_undefined"},
         {:dep_two_variants_same_license, path: "test/fixtures/deps/dep_two_variants_same_license"},
         {:dep_two_conflicting_licenses, path: "test/fixtures/deps/dep_two_conflicting_licenses"},
-        {:dep_one_unrecognized_license_file, path: "test/fixtures/deps/dep_one_unrecognized_license_file"}
+        {:dep_one_unrecognized_license_file, path: "test/fixtures/deps/dep_one_unrecognized_license_file"},
+        {:dep_mock_license, path: "test/fixtures/deps/dep_mock_license"}
       ]
     ]
   end


### PR DESCRIPTION
The `.licensir.exs` file will allow you to specify licenses that are allowed and denied, as well as dependencies that are allowed regardless of their license. If a denied license is found, the mix task will return with an exit status of 1, otherwise it will exit normally with a status of 0.

We're totally open to feedback; we did the minimum to make it work and wanted to get feedback before going much further. 

Currently, the way it works for end-users would be for them to include a `.licensir.exs` file at the root of their project

```elixir
# /.licensir.exs
%{
  allowlist: ["MIT"],
  denylist: ["Apache 2.0"],
  allow_deps: [:poison]
}
```

This updates the CSV and stdout output to include a new `status` column that indicates whether the license is allowed, not allowed, or unknown. For example:

```
Notice: This is not a legal advice. Use the information below at your own risk.
+---------------------+---------+--------------------------------------------------------+---------+
| Package             | Version | License                                                | Status  |
+---------------------+---------+--------------------------------------------------------+---------+
| apex                | 1.2.0   | The MIT License                                        | Allowed |
| certifi             | 2.5.1   | BSD                                                    | Unknown |
| earmark             | 1.2.5   | Apache 2.0                                             | Unknown |
| ex_aws              | 2.1.1   | MIT                                                    | Allowed |
| ex_aws_s3           | 2.0.2   | MIT                                                    | Allowed |
| ex_doc              | 0.18.3  | Apache 2.0                                             | Unknown |
| ex_syslogger        | 1.4.0   | MIT                                                    | Allowed |
| hackney             | 1.15.2  | Apache 2.0                                             | Unknown |
| honeybadger         | 0.10.2  | MIT                                                    | Allowed |
| idna                | 6.0.0   | Unsure (found: BSD, MIT)                               | Unknown |
| jason               | 1.1.0   | Apache 2.0                                             | Unknown |
| junit_formatter     | 3.1.0   | Apache 2.0                                             | Unknown |
| logger_json         | 4.0.0   | Unsure (found: MIT, LISENSE.md, MIT)                   | Unknown |
| metrics             | 1.0.1   | BSD                                                    | Unknown |
| mime                | 1.3.1   | Apache 2.0                                             | Unknown |
| mimerl              | 1.2.0   | MIT                                                    | Allowed |
| parse_trans         | 3.3.0   | Apache 2.0                                             | Unknown |
| plug                | 1.10.0  | Apache 2.0                                             | Unknown |
| plug_crypto         | 1.1.2   | Apache 2.0                                             | Unknown |
| plug_logger_json    | 0.6.0   | Apache 2.0                                             | Unknown |
| poison              | 3.1.0   | CC0-1.0                                                | Allowed |
| redix               | 0.10.2  | MIT                                                    | Allowed |
| ssl_verify_fun      | 1.1.5   | MIT                                                    | Allowed |
| sweet_xml           | 0.6.6   | Unsure (found: MIT, Unrecognized license file content) | Unknown |
| syslog              | 1.0.6   | Unsure (found: BSD, Unrecognized license file content) | Unknown |
| telemetry           | 0.4.1   | Apache 2.0                                             | Unknown |
| unicode_util_compat | 0.4.1   | Unsure (found: Apache 2.0, BSD)                        | Unknown |
+---------------------+---------+--------------------------------------------------------+---------+
```

I tested this on a normal mix project, and it worked as expected.
For an umbrella app, it would require the `.licensir.exs` file for each application included in the umbrella.

Resolves #6 
