### PR TITLE
renaming CSV module to LicensirCSV

### DIFF
--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -1,4 +1,4 @@
-defmodule CSV do
+defmodule LicensirCSV do
   use CSV.Defaults
 
   alias CSV.Encoding.Encoder

--- a/lib/csv.ex
+++ b/lib/csv.ex
@@ -1,4 +1,4 @@
-defmodule LicensirCSV do
+defmodule Licensir.CSV do
   use CSV.Defaults
 
   alias CSV.Encoding.Encoder

--- a/lib/mix/tasks/licenses.ex
+++ b/lib/mix/tasks/licenses.ex
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Licenses do
   defp render_csv(rows) do
     rows
     |> List.insert_at(0, ["Package", "Version", "License"])
-    |> LicensirCSV.encode()
+    |> Licensir.CSV.encode()
     |> Enum.each(&IO.write/1)
   end
 end

--- a/lib/mix/tasks/licenses.ex
+++ b/lib/mix/tasks/licenses.ex
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Licenses do
   defp render_csv(rows) do
     rows
     |> List.insert_at(0, ["Package", "Version", "License"])
-    |> CSV.encode()
+    |> LicensirCSV.encode()
     |> Enum.each(&IO.write/1)
   end
 end


### PR DESCRIPTION
Module name clashes with CSV application, which uses same name for its module.