### PR TITLE
update the vendorized TableRex and namespace it with Licensir

### DIFF
--- a/lib/mix/tasks/licenses.ex
+++ b/lib/mix/tasks/licenses.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Licenses do
     _ = Mix.Shell.IO.info([:yellow, "Notice: This is not a legal advice. Use the information below at your own risk."])
 
     rows
-    |> TableRex.quick_render!(["Package", "Version", "License"])
+    |> Licensir.TableRex.quick_render!(["Package", "Version", "License"])
     |> IO.puts()
   end
 

--- a/lib/table_rex.ex
+++ b/lib/table_rex.ex
@@ -1,9 +1,9 @@
-defmodule TableRex do
+defmodule Licensir.TableRex do
   @moduledoc """
   TableRex generates configurable, text-based tables for display
   """
-  alias TableRex.Renderer
-  alias TableRex.Table
+  alias Licensir.TableRex.Renderer
+  alias Licensir.TableRex.Table
 
   @doc """
   A shortcut function to render with a one-liner.

--- a/lib/table_rex/cell.ex
+++ b/lib/table_rex/cell.ex
@@ -1,4 +1,4 @@
-defmodule TableRex.Cell do
+defmodule Licensir.TableRex.Cell do
   @moduledoc """
   Defines a struct that represents a single table cell, and helper functions.
 
@@ -14,6 +14,9 @@ defmodule TableRex.Cell do
 
     * `rendered_value`: The stringified value for rendering
 
+    * `wrapped_lines`: A list of 1 or more string values representing
+      the line(s) within the cell to be rendered
+
     * `align`:
       * `:left`: left align text in the cell.
       * `:center`: center text in the cell.
@@ -26,9 +29,9 @@ defmodule TableRex.Cell do
   enable that Cell to work well with the rest of TableRex. It should
   be set to a piece of data that can be rendered to string.
   """
-  alias TableRex.Cell
+  alias Licensir.TableRex.Cell
 
-  defstruct raw_value: nil, rendered_value: "", align: nil, color: nil
+  defstruct raw_value: nil, rendered_value: "", align: nil, color: nil, wrapped_lines: [""]
 
   @type t :: %__MODULE__{}
 
@@ -51,17 +54,48 @@ defmodule TableRex.Cell do
   hindered.
   """
   @spec to_cell(Cell.t()) :: Cell.t()
-  def to_cell(%Cell{rendered_value: rendered_value} = cell) when rendered_value != "", do: cell
+  def to_cell(%Cell{rendered_value: rendered_value} = cell)
+      when is_binary(rendered_value) and rendered_value != "" do
+    %Cell{cell | wrapped_lines: wrapped_lines(rendered_value)}
+  end
 
   def to_cell(%Cell{raw_value: raw_value} = cell) do
-    %Cell{cell | rendered_value: to_string(raw_value)}
+    rendered_value = to_string(raw_value)
+    %Cell{cell | rendered_value: rendered_value, wrapped_lines: wrapped_lines(rendered_value)}
   end
 
   @spec to_cell(any, list) :: Cell.t()
-  def to_cell(value, opts \\ []) do
+  def to_cell(value, opts \\ [])
+
+  def to_cell(list, opts) when is_list(list) do
+    if List.improper?(list) do
+      list
+      |> to_string()
+      |> to_cell(opts)
+    else
+      list
+      |> Enum.join("\n")
+      |> to_cell(opts)
+    end
+  end
+
+  def to_cell(value, opts) do
     opts = Enum.into(opts, %{})
 
-    %Cell{rendered_value: to_string(value), raw_value: value}
+    rendered_value = to_string(value)
+
+    %Cell{
+      raw_value: value,
+      rendered_value: rendered_value,
+      wrapped_lines: wrapped_lines(rendered_value)
+    }
     |> Map.merge(opts)
+  end
+
+  @spec height(Cell.t()) :: integer
+  def height(%Cell{wrapped_lines: lines}), do: length(lines)
+
+  defp wrapped_lines(value) when is_binary(value) do
+    String.split(value, "\n")
   end
 end

--- a/lib/table_rex/column.ex
+++ b/lib/table_rex/column.ex
@@ -1,4 +1,4 @@
-defmodule TableRex.Column do
+defmodule Licensir.TableRex.Column do
   @moduledoc """
   Defines a struct that represents a column's metadata
 

--- a/lib/table_rex/renderer.ex
+++ b/lib/table_rex/renderer.ex
@@ -1,4 +1,4 @@
-defmodule TableRex.Renderer do
+defmodule Licensir.TableRex.Renderer do
   @moduledoc """
   An Elixir behaviour that defines the API Renderers should conform to, allowing
   for display output in a variety of formats.
@@ -11,5 +11,5 @@ defmodule TableRex.Renderer do
   @callback default_options() :: map
 
   @doc "Renders a passed %TableRex.Table{} struct into a string."
-  @callback render(table :: %TableRex.Table{}, opts :: list) :: render_return
+  @callback render(table :: %Licensir.TableRex.Table{}, opts :: list) :: render_return
 end

--- a/lib/table_rex/renderer/text/meta.ex
+++ b/lib/table_rex/renderer/text/meta.ex
@@ -1,9 +1,9 @@
-defmodule TableRex.Renderer.Text.Meta do
+defmodule Licensir.TableRex.Renderer.Text.Meta do
   @moduledoc """
   The data structure for the `TableRex.Renderer.Text` rendering module, it holds results
   of style & dimension calculations to be passed down the render pipeline.
   """
-  alias TableRex.Renderer.Text.Meta
+  alias Licensir.TableRex.Renderer.Text.Meta
 
   defstruct col_widths: %{},
             row_heights: %{},
@@ -15,7 +15,7 @@ defmodule TableRex.Renderer.Text.Meta do
             render_row_separators?: false
 
   @doc """
-  Retreives the "inner width" of the table, which is the full width minus any frame.
+  Retrieves the "inner width" of the table, which is the full width minus any frame.
   """
   def inner_width(%Meta{table_width: table_width, render_vertical_frame?: true}) do
     table_width - 2
@@ -26,14 +26,14 @@ defmodule TableRex.Renderer.Text.Meta do
   end
 
   @doc """
-  Retreives the column width at the given column index.
+  Retrieves the column width at the given column index.
   """
   def col_width(meta, col_index) do
     Map.get(meta.col_widths, col_index)
   end
 
   @doc """
-  Retreives the row width at the given row index.
+  Retrieves the row width at the given row index.
   """
   def row_height(meta, row_index) do
     Map.get(meta.row_heights, row_index)

--- a/lib/table_rex/table.ex
+++ b/lib/table_rex/table.ex
@@ -1,4 +1,4 @@
-defmodule TableRex.Table do
+defmodule Licensir.TableRex.Table do
   @moduledoc """
   A set of functions for working with tables.
 
@@ -6,10 +6,10 @@ defmodule TableRex.Table do
   fields are private and must not be accessed directly. Instead,
   use the functions in this module.
   """
-  alias TableRex.Cell
-  alias TableRex.Column
-  alias TableRex.Renderer
-  alias TableRex.Table
+  alias Licensir.TableRex.Cell
+  alias Licensir.TableRex.Column
+  alias Licensir.TableRex.Renderer
+  alias Licensir.TableRex.Table
 
   defstruct title: nil, header_row: [], rows: [], columns: %{}, default_column: %Column{}
 
@@ -25,7 +25,7 @@ defmodule TableRex.Table do
   ## Examples
 
       iex> Table.new
-      %TableRex.Table{}
+      %Licensir.TableRex.Table{}
 
   """
   @spec new() :: Table.t()
@@ -34,7 +34,7 @@ defmodule TableRex.Table do
   @doc """
   Creates a new table with an initial set of rows and an optional header and title.
   """
-  @spec new(list, list, String.t()) :: Table.t()
+  @spec new(list, list, String.t() | nil) :: Table.t()
   def new(rows, header_row \\ [], title \\ nil) when is_list(rows) and is_list(header_row) do
     new()
     |> put_title(title)
@@ -197,7 +197,7 @@ defmodule TableRex.Table do
 
   def sort(%Table{rows: [first_row | _]}, column_index, _order)
       when length(first_row) <= column_index do
-    raise TableRex.Error,
+    raise Licensir.TableRex.Error,
       message:
         "You cannot sort by column #{column_index}, as the table only has #{length(first_row)} column(s)"
   end
@@ -220,7 +220,7 @@ defmodule TableRex.Table do
   end
 
   defp build_sort_function(_column_index, order) do
-    raise TableRex.Error,
+    raise Licensir.TableRex.Error,
       message: "Invalid sort order parameter: #{order}. Must be an atom, either :desc or :asc."
   end
 
@@ -233,7 +233,7 @@ defmodule TableRex.Table do
   end
 
   @doc """
-  Retreives the value of a column meta option at the specified col_index.
+  Retrieves the value of a column meta option at the specified col_index.
   If no value has been set, default values are returned.
   """
   @spec get_column_meta(Table.t(), integer, atom) :: any
@@ -291,7 +291,7 @@ defmodule TableRex.Table do
   def render!(%Table{} = table, opts \\ []) when is_list(opts) do
     case render(table, opts) do
       {:ok, rendered_string} -> rendered_string
-      {:error, reason} -> raise TableRex.Error, message: reason
+      {:error, reason} -> raise Licensir.TableRex.Error, message: reason
     end
   end
 end


### PR DESCRIPTION
Besides updating the TableRex code, this allows Licensir to be used with other libraries that use TableRex as a dependency such as `ecto_psql_extras`